### PR TITLE
Bugfix/tern multiple layers

### DIFF
--- a/1/dind-tern/Dockerfile
+++ b/1/dind-tern/Dockerfile
@@ -3,8 +3,12 @@ FROM docker:dind
 RUN apk --no-cache add \
       git \
       findutils \
+      util-linux \
+      tar \
+      cifs-utils \
+      nfs-utils \
       attr && \
-    rm -rf /var/cache/apk/*
+      rm -rf /var/cache/apk/*
 
 RUN apk add python3
 
@@ -13,4 +17,7 @@ RUN pip3 install --upgrade pip && pip3 install tern
 ADD REPO .
 ADD TAGS .
 
-CMD ["sh"]  
+RUN mkdir hostmount
+
+ENTRYPOINT ["tern", "-b", "/hostmount"]
+CMD ["-h"]

--- a/README.md
+++ b/README.md
@@ -29,9 +29,15 @@ docker run --privileged -it --rm -v /var/run/docker.sock:/var/run/docker.sock te
 
 Tern makes it very easy to extract Docker images BOMs. All the available export formats are available on the [official docs](https://github.com/vmware/tern)
 
+_It is necessary to bind a mount dir to the Docker container first_
+
 Example:
 
-```tern report -f json -i debian:buster > debian_buster.json```
+```bash
+mkdir my_dir
+
+docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock --mount type=bind,source=$PWD/my_dir,target=/hostmount --rm philipssoftware/tern report -f json -i debian:buster > debian.json
+```
 
 This command will create a file called `debian_buster.json` with Debian's Buster [official image](https://hub.docker.com/layers/debian/library/debian) BOM
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Example:
 ```bash
 mkdir my_dir
 
-docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock --mount type=bind,source=$PWD/my_dir,target=/hostmount --rm philipssoftware/tern report -f json -i debian:buster > debian.json
+docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock --mount type=bind,source=$PWD/my_dir,target=/hostmount --rm philipssoftware/tern report -f json -i debian:buster > debian_buster.json
 ```
 
 This command will create a file called `debian_buster.json` with Debian's Buster [official image](https://hub.docker.com/layers/debian/library/debian) BOM


### PR DESCRIPTION
@JeroenKnoops these latest changes enable `tern` to scan all Docker images. Our current setup only allows images with a single layer to be scanned.

Furthermore, the current setup enables scanning Docker images in CI/CD pipelines, but it is quite limited in terms of the images it is able to scan.

If this PR is approved, however, CI/CD will no longer be possible due to the constraints which are necessary when _running_ this Docker image. On the other hand, it allows clients to run this image directly from Linux environments by specifying the right args.

I am open to discuss which approach we should take for now.

