### PR TITLE
Add signing and SLSA Provenance

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -7,6 +7,9 @@ env:
   DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
   DOCKER_ORGANIZATION: philipssoftware
   GITHUB_ORGANIZATION: philips-software
+  COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
+  COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
+  COSIGN_PUBLIC_KEY: '${{ secrets.COSIGN_PUBLIC_KEY  }}'
 
 jobs:
   build_tern:
@@ -33,7 +36,9 @@ jobs:
         with:
           dockerfile: ${{ matrix.dockerfile }} 
           image-name: tern
-          tags: ${{ matrix.tags }} 
+          tags: ${{ matrix.tags }}
+          slsa-provenance: true
+          sign: true
 
   manual_build:
     name: tern manual
@@ -50,6 +55,8 @@ jobs:
           image-name: tern
           tags: latest-scancode
           base-dir: latest/tern
+          slsa-provenance: true
+          sign: true
 
       - name: setup python 
         uses: actions/setup-python@v2.3.1
@@ -68,3 +75,5 @@ jobs:
           dockerfile: local/tern/docker/Dockerfile.local
           image-name: tern
           tags: local
+          slsa-provenance: true
+          sign: true

--- a/README.md
+++ b/README.md
@@ -43,6 +43,27 @@ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock philipssoftware/ter
 
 This command will create a file called `debian_buster.json` with Debian's Buster [official image](https://hub.docker.com/layers/debian/library/debian) BOM
 
+## SLSA-provenance and signing
+
+The images have a provenance attached to it and are signed. You can verify these.
+
+### Signing
+
+You can verify the image with [Cosign](https://github.com/sigstore/cosign).
+
+```bash
+cosign verify --key cosign.pub philipssoftware/tern | jq .
+```
+
+### SLSA-provenance
+
+You can verify the provenance file with [Cosgin](https://github.com/sigstore/cosgin).
+
+```bash
+repodigest=$(docker inspect philipssoftware/tern | jq -r .[0].RepoDigests[0])
+cosign verify-attestation --key cosign.pub $repodigest | jq -r '.payload' | base64 -d | jq .
+```
+
 ## Content
 
 The images obviously contains Tern, but also two other files:

--- a/cosign.pub
+++ b/cosign.pub
@@ -1,0 +1,4 @@
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEEGlpgsq8wwzsbQz0/iB2JNwn22Wq
+6IRccAka2ZmCCet9fJ4+sWE9q00BwlwRvuCT9zSsr/307pNkcX2dQ/8nbA==
+-----END PUBLIC KEY-----


### PR DESCRIPTION
Add signing and SLSA Provenance.

This is now supported in docker-ci-scripts.